### PR TITLE
fix filename/region sorting, wavelength type to int 

### DIFF
--- a/ndviewer_hcs/__init__.py
+++ b/ndviewer_hcs/__init__.py
@@ -3,7 +3,7 @@
 A modular viewer for high-content screening data with preprocessing and visualization.
 """
 
-from .common import TileData, parse_filenames
+from .common import TileData, parse_filenames, extract_wavelength
 from .preprocessing import PlateAssembler
 from .viewer import TiffViewerWidget, ViewerMainWindow
 from .gui_config import ConfigurationGUI
@@ -12,6 +12,7 @@ from .ndviewer_hcs import main
 __all__ = [
     'TileData',
     'parse_filenames',
+    'extract_wavelength',
     'PlateAssembler',
     'TiffViewerWidget',
     'ViewerMainWindow',


### PR DESCRIPTION
filename sorting now (fov,region,c,z,t), wavelength type to int, region sorting helper builtin method 'sorted' caused mapping errors ('AA' before 'Z')